### PR TITLE
[Fix] Issue

### DIFF
--- a/app/(signUp)/signup/components/step2_AgentSelection.tsx
+++ b/app/(signUp)/signup/components/step2_AgentSelection.tsx
@@ -13,7 +13,6 @@ const Step2_AgentSelection = () => {
     setBusinessName,
     setOfficeAddress,
     setOwnerName,
-    setAgentSpecialty,
     setPrimaryContactNumber,
   } = useStepContext();
   const [searchQuery, setSearchQuery] = useState<string>("");
@@ -112,7 +111,6 @@ const Step2_AgentSelection = () => {
                   setAgentRegistrationNumber(office.개설등록번호);
                   setBusinessName(office.중개사무소명);
                   setOfficeAddress(office.소재지도로명주소);
-                  setAgentSpecialty(office.소재지도로명주소);
                   setSelectedOffice(office);
                   setPrimaryContactNumber(office.전화번호);
                   setIsOpen(false);

--- a/app/(signUp)/signup/components/termsAreement.tsx
+++ b/app/(signUp)/signup/components/termsAreement.tsx
@@ -88,21 +88,25 @@ const TermsAgreement = ({ className }: TermsAgreementProps) => {
       {/* ✅ 개별 동의 항목 */}
       {[
         {
-          label: "이용약관에 동의합니다.",
+          label: "(필수) 이용약관에 동의합니다.",
           state: termsAgree,
           setter: setTermsAgree,
         },
         {
-          label: "개인정보 처리방침에 동의합니다.",
+          label: "(필수) 개인정보 처리방침에 동의합니다.",
           state: privacyAgree,
           setter: setPrivacyAgree,
         },
         {
-          label: "집플 서비스 운영 정책에 동의합니다.",
+          label: "(필수) 집플 서비스 운영 정책에 동의합니다.",
           state: serviceAgree,
           setter: setServiceAgree,
         },
-        { label: "만 14세 이상입니다.", state: ageAgree, setter: setAgeAgree },
+        {
+          label: "(필수) 만 14세 이상입니다.",
+          state: ageAgree,
+          setter: setAgeAgree,
+        },
       ].map(({ label, state, setter }, index) => (
         <div
           key={index}
@@ -141,7 +145,7 @@ const TermsAgreement = ({ className }: TermsAgreementProps) => {
             <FaCircle className="text-gray-300 md:text-h3 text-mobile_h4" />
           )}
           <span className="md:text-body1_r text-mobile_body2_r">
-            마케팅 알림 수신 동의
+            (선택) 마케팅 알림 수신 동의
           </span>
         </div>
         <p

--- a/app/api/login/api.ts
+++ b/app/api/login/api.ts
@@ -28,6 +28,7 @@ export const refreshAccessToken = async () => {
     console.error("토큰 갱신 실패");
     signOut();
     window.location.href = "/";
+    alert("세션이 만료되었습니다.\n다시 로그인해주세요.");
     return null;
   }
 };

--- a/app/components/layout/footer.tsx
+++ b/app/components/layout/footer.tsx
@@ -35,7 +35,7 @@ const Footer = () => {
 
           <div className="flex flex-row gap-10">
             {/* 집플 정보 */}
-            <div className="md:flex hidden flex-col gap-4">
+            {/* <div className="md:flex hidden flex-col gap-4">
               <h3 className="text-base font-semibold text-white">집플 정보</h3>
               <ul className="flex flex-col gap-2.5 text-xs text-white">
                 <p>서비스 소개</p>
@@ -44,16 +44,16 @@ const Footer = () => {
                 <p>집플래너</p>
                 <p>커뮤니티</p>
               </ul>
-            </div>
+            </div> */}
             {/* 고객 안내 */}
-            <div className="md:flex hidden flex-col gap-4">
+            {/* <div className="md:flex hidden flex-col gap-4">
               <h3 className="text-base font-semibold text-white">고객 안내</h3>
               <ul className="flex flex-col gap-2.5 text-xs text-white">
                 <p>공지사항</p>
                 <p>이용안내</p>
                 <p>자주 묻는 질문</p>
               </ul>
-            </div>
+            </div> */}
             {/* 고객 센터 */}
             <div className="md:flex hidden flex-col gap-4 mt-5 md:mt-0">
               <h3 className="text-base font-semibold text-white">고객 센터</h3>

--- a/app/components/user/agentUser.tsx
+++ b/app/components/user/agentUser.tsx
@@ -287,6 +287,7 @@ const AgentUser = () => {
                   name="phoneNumber"
                   value={basicInfo.phoneNumber}
                   onChange={handleBasicChange}
+                  disabled={true}
                 />
                 <CustomInput
                   label="이메일"
@@ -300,12 +301,12 @@ const AgentUser = () => {
                   value={detailInfo.externalLink}
                   onChange={handleDetailChange}
                 />
-                <CustomInput
+                {/* <CustomInput
                   label="한 줄 소개"
                   name="title"
                   value={detailInfo.title}
                   onChange={handleDetailChange}
-                />
+                /> */}
                 <CustomInput
                   label="자기소개"
                   name="content"
@@ -348,15 +349,15 @@ const AgentUser = () => {
                     </p>
                   </a>
                 </div>
-
-                <div className="flex flex-row items-center gap-1 ml-4">
+                {/* 자기소개 제목 */}
+                {/* <div className="flex flex-row items-center gap-1 ml-4">
                   <p className="text-gray-600 text-body1_sb">
-                    <FaIdBadge /> {/* 자기소개 제목 */}
+                    <FaIdBadge /> 
                   </p>
                   <p className="text-mobile_body2_r md:text-body1_r pl-5">
                     {detailInfo.title}
                   </p>
-                </div>
+                </div> */}
                 <div className="flex flex-row items-center gap-1 ml-4">
                   <p className="text-gray-600 text-body1_sb">
                     <FaPen /> {/* 자기소개 내용 */}

--- a/app/stores/userStore.ts
+++ b/app/stores/userStore.ts
@@ -48,10 +48,17 @@ export const authStore = createStore<AuthStore>()(
             isRegistered,
             userInfo,
           })),
-        signOut: () =>
+        signOut: () => {
+          // 상태 초기화
           set(() => ({
             ...defaultAuthState,
-          })),
+          }));
+
+          // 로컬/세션 스토리지에서 auth 관련 정보 제거
+          sessionStorage.removeItem("accessToken");
+          // sessionStorage.removeItem("refreshToken");
+          localStorage.removeItem("authStorage");
+        },
         setUserData: (userData) =>
           set(() => ({
             userInfo: userData,


### PR DESCRIPTION
# Issue

### 🚀 기능 목록
- 유효성 검사
- 회원가입

### ✅ 작업 내용
- 회원가입 과정에서 전문분야 필드 '아파트' 선택 시, 에러 발생 수정 -> 2단계에서 동일 필드에 값을 저장하고 있었음
- 인증 완료 후, 이전에 나타났던 에러 메세지 삭제 반영 -> 성공 시, 에러 메세지 `null` 처리
- 약관 동의 필수/선택 값 표시 -> 약관 문구 앞에 `(필수/선택)` 문구 추가
- 회원 가입 4단계 유효성 검사 추가 (전문 분야 선택/서류 첨부/필수 약관 동의) -> 2, 3 단계도 유효성 검사 필요
- 마이페이지 전화번호 수정 불가 필드로 변경 -> 인증 후 수정할 수 있도록 변경
- 중개사 마이페이지 한 줄 소개 삭제 -> 자기소개 필드만 유지

### 📌 추가 정보
- refreshToken API 확인 필요
- 401 에러가 아닌 500 에러로 반환되어 refreshToken API 호출 불가 => 회원 정보 API에서 강제 호출

